### PR TITLE
fix broken link in README, H1 link: current-one-has-hyphens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[Google Font Explorer](http://katydecorah.com/googlefontexplorer/)
+[Google Font Explorer](http://katydecorah.com/google-font-explorer/)
 ==================
 
 Preview [Google Fonts](http://www.google.com/fonts) better! You can test any Google Font family by typing it in. You can edit the lorem ipsum. You can even randomize to find a new family. The info button will give you the link href.


### PR DESCRIPTION
Like this webapp, had it bookmarked earlier, which is how I found out about the broken link ..., fixed here.
