### PR TITLE
https iso http

### DIFF
--- a/js/lib/main.js
+++ b/js/lib/main.js
@@ -539,7 +539,7 @@ function runFont(family) {
     $.each(json.items,function(i,type){
       if (type.family === family) {
         var familyPlus = family.replace(/\s/g, '+');
-        var familyCSS = "http://fonts.googleapis.com/css?family=" + familyPlus + ":" + type.variants + "";
+        var familyCSS = "https://fonts.googleapis.com/css?family=" + familyPlus + ":" + type.variants + "";
         var details = $("#variants");
 
         // Removes previous family and style


### PR DESCRIPTION
I like this webapp, though I like your newer Font Library even better. Is this one deprecated? Anyhow, like it is now, the fontloading is blocked loading mixed active content

> jquery.js:5216 Mixed Content: The page at 'https://katydecorah.com/google-font-explorer/' was loaded over HTTPS, but requested an insecure stylesheet 'http://fonts.googleapis.com/css?family=Monofett:regular'. This request has been blocked; the content must be served over HTTPS.

Somehow I can't seem to make the grunt command work though, so maybe this still needs some work